### PR TITLE
Fix recipe plaintext link

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ layout: default
     <div class="sm-col-6 mx-auto px3 sm-px4">
   <p>Hey folks!</p>
   <p>My name's Clark and you've just stumbled into <strong>Chowdown</strong>, a plain text recipe database for hackers. Over the years, I've tried dozens of recipe apps and services in an attempt to eat better and get more organized. With each app came a new format and <em>recipe lock-in</em>, neither of which got me excited.</p>
-  <p><strong>Chowdown</strong> is my attempt at fixing recipe app burnout, by moving my recipes out of closed services and into plain text. For example, here's <a href="https://raw.githubusercontent.com/clarklab/chowdown/gh-pages/_recipes/broccoli-cheese-soup.md">a recipe in plain text</a> that I've been working on for a while. It's a broccoli beer cheese soup inspired by Gourmand's, one of my favorite spots in Austin. Crazy delicious.</p>
+  <p><strong>Chowdown</strong> is my attempt at fixing recipe app burnout, by moving my recipes out of closed services and into plain text. For example, here's <a href="https://raw.githubusercontent.com/clarklab/chowdown/master/_recipes/broccoli-cheese-soup.md">a recipe in plain text</a> that I've been working on for a while. It's a broccoli beer cheese soup inspired by Gourmand's, one of my favorite spots in Austin. Crazy delicious.</p>
   
   <p><a href="http://chowdown.io/recipes/broccoli-cheese-soup.html">Here's that same recipe processed with <strong>Chowdown</strong>.</a> It's a simple layout with a photo, ingredient list, and directions.</p>
   


### PR DESCRIPTION
The plaintext version of the recipe doesn't exist in the `gh-pages` branch.

Fixes #5 