### PR TITLE
Added baseurl to footer links, typo fix

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,10 +5,10 @@
     
     <div class="clearfix">
       <div class="sm-col sm-col-6">
-        <p class="left-align rss-subscribe mb2"><a href="/search">Search</a>  | <a href="/blog">Blog</a> | </a>Subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+        <p class="left-align rss-subscribe mb2"><a href="{{ "/search" | prepend: site.baseurl}}">Search</a>  | <a href="{{ "/blog" | prepend: site.baseurl}}">Blog</a> | </a>Subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
       </div>
       <div class="sm-col sm-col-6">
-        <p class="right-align mb2">Made with <svg class="js-geomicon geomicon" height="0.8em" data-icon="heart" viewBox="0 0 32 32" style="fill:#007FFF"><title>heart icon</title><path d="M0 10 C0 6, 3 2, 8 2 C12 2, 15 5, 16 6 C17 5, 20 2, 24 2 C30 2, 32 6, 32 10 C32 18, 18 29, 16 30 C14 29, 0 18, 0 10"></path></svg> by <a href="http://twiter.com/clarklab">@clarklab</a></p>
+        <p class="right-align mb2">Made with <svg class="js-geomicon geomicon" height="0.8em" data-icon="heart" viewBox="0 0 32 32" style="fill:#007FFF"><title>heart icon</title><path d="M0 10 C0 6, 3 2, 8 2 C12 2, 15 5, 16 6 C17 5, 20 2, 24 2 C30 2, 32 6, 32 10 C32 18, 18 29, 16 30 C14 29, 0 18, 0 10"></path></svg> by <a href="http://twitter.com/clarklab">@clarklab</a></p>
       </div>
     </div>
     


### PR DESCRIPTION
Updated Search and Blog links to prepend baseurl, so the links work when running in a subfolder (similar to https://github.com/clarklab/chowdown/issues/11).

Also corrected typo in twitter URL.