### PR TITLE
Updated search.html paths for search js and json

### DIFF
--- a/search.html
+++ b/search.html
@@ -20,14 +20,14 @@ layout: default
 
 
 <!-- Script pointing to search-script.js -->
-<script src="/plugins/simple-jekyll-search.min.js" type="text/javascript"></script>
+<script src="{{site.baseurl}}/plugins/simple-jekyll-search.min.js" type="text/javascript"></script>
 
 <!-- Configuration -->
 <script>
 SimpleJekyllSearch({
   searchInput: document.getElementById('search-input'),
   resultsContainer: document.getElementById('results-container'),
-  json: '/search.json',
+  json: '{{site.baseurl}}/search.json',
   searchResultTemplate: '<div class="sm-col sm-col-6 md-col-6 lg-col-4 xs-px1 xs-mb2 left-align"><a class="block relative bg-blue" href="{url}"><div class="image ratio bg-cover" style="background-image:url({{site.baseurl}}/images/{image});"></div><h1 class="title p2 m0 absolute bold white bottom-0 left-0">{title}</h1></a></div>'
 })
 </script>


### PR DESCRIPTION
Updated path in search.html for "simple-jekyll-search.min.js" and "search.json" to include site.baseurl, to correct for issues when site is running in a sub-folder.