### PR TITLE
sanitize ingredients when adding to search index

### DIFF
--- a/search.json
+++ b/search.json
@@ -5,7 +5,7 @@
     {
     
 	    "title"    : "{{ post.title | escape }}",
-		{% if post.ingredients %}"ingredients"    : "{% for ingredient in post.ingredients %}{{ ingredient }}, {% endfor %}",{% endif %}
+		{% if post.ingredients %}"ingredients"    : "{% for ingredient in post.ingredients %}{{ ingredient | escape }}, {% endfor %}",{% endif %}
 		"image"	   : "{{ post.image }}",
 	    "url"      : "{{ site.baseurl }}{{ post.url }}"
       


### PR DESCRIPTION
Quotation marks in ingredients list currently causes search.json to fail to build correctly. Updated to sanitize for json when indexing.

Should correct issue https://github.com/clarklab/chowdown/issues/13 .