### PR TITLE
Updated URLs for blog posts to include site.baseurl

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -9,8 +9,8 @@ layout: default
 
   {% for post in site.posts %}
   <div class="post mb4">
-    <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
-    <p>{{ post.content | strip_html | truncatewords:20 }} <a href="{{ post.url }}">View Post</a></p>
+    <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+    <p>{{ post.content | strip_html | truncatewords:20 }} <a href="{{ site.baseurl }}{{ post.url }}">View Post</a></p>
   </div>
   {% endfor %}
 


### PR DESCRIPTION
Added site.baseurl to generated blog post links, to fix 404 issue when site isn't at root.