### PR TITLE
Books feature

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,8 @@ collections:
     output: true
   recipes:
     output: true
+  books:
+    output: true
 
 exclude: ['Gemfile', 'Gemfile.lock', 'Rakefile', 'README.md']
 

--- a/_data/people.yml
+++ b/_data/people.yml
@@ -1,0 +1,8 @@
+# Store your people here
+# eg:
+#
+# clarklab:
+#   name: Clark Wimberly
+#   twitter: @clarklab
+#   web: http://clarklab.com
+#

--- a/_includes/book-preview.html
+++ b/_includes/book-preview.html
@@ -1,4 +1,5 @@
 {% assign thisbook = include.book %}
+
 <div class="col sm-col-12 md-col-12 lg-col-6 sm-p2" itemscope itemtype="http://schema.org/Book">
   <meta itemprop="bookFormat" content="EBook"/>
   <meta itemprop="genre" content="cooking"/>
@@ -26,3 +27,6 @@
   </div>
 
 </div>
+
+{% assign author = nil %}
+{% assign thisbook = nil %}

--- a/_includes/book-preview.html
+++ b/_includes/book-preview.html
@@ -1,0 +1,28 @@
+{% assign thisbook = include.book %}
+<div class="col sm-col-12 md-col-12 lg-col-6 sm-p2" itemscope itemtype="http://schema.org/Book">
+  <meta itemprop="bookFormat" content="EBook"/>
+  <meta itemprop="genre" content="cooking"/>
+
+  <div class="col sm-col-12 md-col-2 lg-col-3">
+    <img src="/images/{{ thisbook.cover }}" itemprop="image" />
+  </div>
+
+  <div class="col sm-col-12 md-col-10 lg-col-9 px2">
+    <div class="">
+      <h3 class="h1 mt0" itemprop="name">{{ thisbook.title }}</h3>
+      {% if thisbook.author %}
+        {% assign author = site.data.people[thisbook.author] %}
+        <h4 class="gray h5">by {{ author.name }}</h4>
+      {% endif %}
+      <p class="italic" itemprop="description">{{ thisbook.description }}</p>
+      <p class="h5" itemprop="abstract">
+        {{ thisbook.covernotes }}
+      </p>
+
+      {% unless page.url == thisbook.url %}
+      <a class="button button-transparent blue" href="{{ thisbook.url }}">Read on...</a>
+      {% endunless %}
+    </div>
+  </div>
+
+</div>

--- a/_includes/recipe-preview.html
+++ b/_includes/recipe-preview.html
@@ -1,0 +1,7 @@
+{% assign thisrecipe = include.recipe %}
+
+<a class="col col-12 sm-col-4 md-col-4 lg-col-3 button button-transparent blue" href="{{ thisrecipe.url }}">
+  {{ thisrecipe.title }}
+</a>
+
+{% assign thisrecipe = nil %}

--- a/_includes/related-books.html
+++ b/_includes/related-books.html
@@ -1,0 +1,12 @@
+{% assign booklist = site.books | where: 'id', page.books %}
+
+{% if booklist.first %}
+<aside class="books clearfix">
+  <div class="components bg-darken-2 p2 mt3 mb3 center">
+    This recipe appears in these books
+  </div>
+  {% for book in booklist %}
+  {% include book-preview.html book=book %}
+  {% endfor %}
+</aside>
+{% endif %}

--- a/_includes/related-books.html
+++ b/_includes/related-books.html
@@ -1,12 +1,18 @@
-{% assign booklist = site.books | where: 'id', page.books %}
+{% assign thisRecipe = include.recipe %}
+{% assign bookIds = thisRecipe.books %}
 
-{% if booklist.first %}
+{% if thisRecipe.books %}
 <aside class="books clearfix">
   <div class="components bg-darken-2 p2 mt3 mb3 center">
     This recipe appears in these books
   </div>
-  {% for book in booklist %}
-  {% include book-preview.html book=book %}
+  {% for book in site.books %}
+    {% for thisRecipeBookId in thisRecipe.books %}
+      {% assign bookId = thisRecipeBookId | prepend: "/books/" %}
+      {% if book.id == bookId %}
+        {% include book-preview.html book=book %}
+      {% endif %}
+    {% endfor %}
   {% endfor %}
 </aside>
 {% endif %}

--- a/_includes/related-books.html
+++ b/_includes/related-books.html
@@ -10,3 +10,5 @@
   {% endfor %}
 </aside>
 {% endif %}
+
+{% assign booklist = nil %}

--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{% assign pageAuthor = site.data.people[page.author] %}
 
 <div class="container">
   <article class="post-content px2 clearfix">
@@ -24,9 +25,8 @@ layout: default
   <aside class="px2 clearfix">
     <div class="components bg-darken-2 p2 mt3 mb3 center">
       Books
-      {% assign author = site.data.people[page.author] %}
-      {% if author %}
-      by <span class="blue">{{ author.name }}</span>
+      {% if pageAuthor %}
+      by <span class="blue">{{ pageAuthor.name }}</span>
       {% endif %}
     </div>
     <div class="p2">

--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -24,14 +24,14 @@ layout: default
 
   <aside class="px2 clearfix">
     <div class="components bg-darken-2 p2 mt3 mb3 center">
-      Books
+      Other books
       {% if pageAuthor %}
       by <span class="blue">{{ pageAuthor.name }}</span>
       {% endif %}
     </div>
     <div class="p2">
     {% for book in site.books %}
-      {% if book.author == page.author %}
+      {% if book.author == page.author and book.id != page.id %}
         {% include book-preview.html book=book %}
       {% endif %}
     {% endfor %}

--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -1,0 +1,40 @@
+---
+layout: default
+---
+
+<div class="container">
+  <article class="post-content px2 clearfix">
+    {{ content }}
+  </article>
+
+  <aside class="px2 clearfix">
+    <div class="components bg-darken-2 p2 mt3 mb3 center">
+      Recipes in this book
+    </div>
+    {% assign bookid = page.id | split: '/' | last %}
+    <div class="p2">
+    {% for recipe in site.recipes %}
+      {% if recipe.books contains bookid %}
+        {% include recipe-preview.html recipe=recipe %}
+      {% endif %}
+    {% endfor %}
+    </div>
+  </aside>
+
+  <aside class="px2 clearfix">
+    <div class="components bg-darken-2 p2 mt3 mb3 center">
+      Books
+      {% assign author = site.data.people[page.author] %}
+      {% if author %}
+      by <span class="blue">{{ author.name }}</span>
+      {% endif %}
+    </div>
+    <div class="p2">
+    {% for book in site.books %}
+      {% if book.author == page.author %}
+        {% include book-preview.html book=book %}
+      {% endif %}
+    {% endfor %}
+    </div>
+  </aside>
+</div>

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -127,6 +127,7 @@ layout: default
     <p class="clearfix">{{ site.translation[site.language].category }}: <span itemprop="recipeCategory">{{ category }}</span></p>
   {% endfor %}
 
+  {% include related-books.html %}
   </article>
 
 </div>

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -127,7 +127,7 @@ layout: default
     <p class="clearfix">{{ site.translation[site.language].category }}: <span itemprop="recipeCategory">{{ category }}</span></p>
   {% endfor %}
 
-  {% include related-books.html %}
+  {% include related-books.html recipe=page %}
   </article>
 
 </div>

--- a/books.html
+++ b/books.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+
+<div class="container">
+
+  <h1>Books</h1>
+  <p>Here's all the lovely books we have.</p>
+
+  <div class="clearfix">
+  {% for book in site.books %}
+  {% include book-preview.html book=book %}
+  {% endfor %}
+  </div>
+
+</div>


### PR DESCRIPTION
This is an idea of how books might work. The hope is that it will provoke discussion and help drive towards what might be useful (if this does turn out to be useful at all.)

They way I have it setup in this example is to use a `books` collection with its own layout that has no exciting structure. The author is free to lay it out as they see fit and either inject recipes using a standard looking `include` (not yet written) or just write them out in their own way. The book can be quite free-form in this manner as I think @clarklab was keen on. The clever part comes form the recipe end.

In recipes you can mark them as being *part of* any number of books. 
```yaml
books: [my-awesome-book]
```

This keeps the association with the recipe and makes life a bit easier. When viewing a recipe you can see which books it is in:

![image](https://user-images.githubusercontent.com/15760/80742858-f4726a80-8b13-11ea-9b97-e3063f22495e.png)

Also, at the bottom of the book you can see an index of the recipes that refer to it, and a list of books by the same author:

![image](https://user-images.githubusercontent.com/15760/80744592-d2c6b280-8b16-11ea-984e-65bf90ab6d39.png)

Authors are identified in `_data/people.yml` - which no doubt will find uses elsewhere. We could even use them as the 'chef' of a recipe?

As I say, although very much a functioning idea, this is still just an *idea* and open to ravaging change. 