### PR TITLE
search input functionality

### DIFF
--- a/search.html
+++ b/search.html
@@ -150,6 +150,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Event listener for toggling filters
   filterButton.addEventListener('click', toggleFilters);
+
+  // Event listener for search input bar
+  searchInput.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') {
+      simpleSearch.search(searchInput.value);
+      showResults();
+    }
+  });
 });
 
 


### PR DESCRIPTION
The search input does not have any functionality by default (it is filled with the ingredient or tag that is clicked, but typing manually does not work). This fixes that.